### PR TITLE
Remove staging plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,17 +135,6 @@
 					<target>${java.version}</target>
 				</configuration>
 			</plugin>
-			<plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                  <nexusUrl>${nexusproxy}</nexusUrl>
-                  <stagingProfileId>a004df83a6249</stagingProfileId>
-                  <serverId>staging</serverId>
-                </configuration>
-            </plugin>
 		</plugins>
 	</build>
 	<repositories>


### PR DESCRIPTION
This conflicts with the way we have maven clean deploy
set up and we do not need it.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>