### PR TITLE
Update setup.py to use versioned dependencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -61,6 +61,6 @@ setup(
 	
 	#if platform.system() == 'Linux':
 	#	requirements.extend([])
-    install_requires=['flask', 'bacpypes','pyyaml'],
+    install_requires=['flask==1.0.2', 'bacpypes==0.16.7','pyyaml==3.13'],
     
 )


### PR DESCRIPTION
The python element of the bacnet device service requires an older version of the bacpypes library (breaking change in 0.17.x). I've updated the script to use a fixed version (0.16.7), additionally I've fixed the versions of the flask and pyyaml libraries. 